### PR TITLE
Include numeric for using std::accumulate

### DIFF
--- a/APE/APEHist.hpp
+++ b/APE/APEHist.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <mutex>
 #include <atomic>
+#include <numeric>
 
 namespace APEUtils{
   class Locksmith{


### PR DESCRIPTION
Hi @samikama - when converting the atlasexternals build to the new github location for APE I got a build failure from the lack of the `numeric` header (for `std::accumulate`).

This pull request fixes than and then APE builds cleanly, so if you accept I will continue with my update for the externals.

Thanks.